### PR TITLE
Fix undefined inline functions and remove superfluous sample id assignment

### DIFF
--- a/Audio/olcPGEX_AudioListener.h
+++ b/Audio/olcPGEX_AudioListener.h
@@ -174,7 +174,7 @@ public:
 			wav = wavPtr;
 		}
 
-		int nSampleID = GAME2D::AUDIO::NULL_SND; // requires PGE_GAME_2D_Constants.h to be included (or just modify this to suit your own needs...)
+		int nSampleID;
 		SoLoud::Wav* wav;
 	};
 

--- a/Audio/olcPGEX_AudioListener.h
+++ b/Audio/olcPGEX_AudioListener.h
@@ -199,20 +199,20 @@ public:
 
 
 	// Initialise the Audio Engine, and Destroy it when done
-	inline void AudioSystemInit();
-	inline void AudioSystemDestroy();
+	void AudioSystemInit();
+	void AudioSystemDestroy();
 
 	// Load a file and store it in the list of wavs
-	inline void LoadAudioSample(int ID, const char* fileName);
+	void LoadAudioSample(int ID, const char* fileName);
 
 	// Identify a particular Audio Sample based on its ID
-	inline sAudioSample* GetAudioSampleByID(int ID);
+	sAudioSample* GetAudioSampleByID(int ID);
 
 	// Update the spacial position of the Audio Listener
-	inline void UpdatePosition(olc::vf2d pos);
+	void UpdatePosition(olc::vf2d pos);
 
 	// Calculate distance between listener and source
-	inline float GetDistance(olc::vf2d sourcePos, bool returnRoot = true);
+	float GetDistance(olc::vf2d sourcePos, bool returnRoot = true);
 };
 
 #ifdef AUDIO_LISTENER_IMPLEMENTATION

--- a/Audio/olcPGEX_AudioSource.h
+++ b/Audio/olcPGEX_AudioSource.h
@@ -103,25 +103,25 @@ public:
 
 
 	// Instruct Audio Listener to load this sound (if not loaded already)
-	inline void LoadAudioSample(int ID, const char* fileName);
+	void LoadAudioSample(int ID, const char* fileName);
 
 	// Play the Audio Sample, with given parameters
-	inline void Play(float speed = 1.0f, float vol = 1.0f, bool looping = false, bool paused = false);
+	void Play(float speed = 1.0f, float vol = 1.0f, bool looping = false, bool paused = false);
 
 	// Pause or Un-Pause - maintains the playback position and handle
-	inline void Pause(bool pauseState = true);
+	void Pause(bool pauseState = true);
 
 	// Stop - playback position and handle will be lost
-	inline void Stop();
+	void Stop();
 
 	// Audio Modulation - control the speed of playback
-	inline void ModulateAudio(float minPlaySpeed, float maxPlaySpeed, float modulation, bool precise = false, bool deferred = false);
+	void ModulateAudio(float minPlaySpeed, float maxPlaySpeed, float modulation, bool precise = false, bool deferred = false);
 
 	// Adjust Volume
-	inline void SetVolume(float vol, float minVol = 0.0f, float maxVol = 1.0f);
+	void SetVolume(float vol, float minVol = 0.0f, float maxVol = 1.0f);
 
 	// Set Default Parameters
-	inline void SetDefaults(float speed, float vol, float minVol, float maxVol, bool looping);
+	void SetDefaults(float speed, float vol, float minVol, float maxVol, bool looping);
 };
 
 #ifdef AUDIO_SOURCE_IMPLEMENTATION


### PR DESCRIPTION
When I tried to compile, i got the following warnings and error:

```bash
jon@Jonny-PC:~/Projects/Untitled$ make
g++ -std=c++17 -ggdb3 -Og -Bstatic -static-libgcc -static-libstdc++ -Iinclude -I/opt/libraries/soloud20200207/include -c -o obj/SceneSplash.o src/SceneSplash.cpp
g++ -std=c++17 -ggdb3 -Og -Bstatic -static-libgcc -static-libstdc++ -Iinclude -I/opt/libraries/soloud20200207/include -c -o obj/vendor.o src/vendor.cpp
g++ -std=c++17 -ggdb3 -Og -Bstatic -static-libgcc -static-libstdc++ -Iinclude -I/opt/libraries/soloud20200207/include -c -o obj/main.o src/main.cpp
In file included from include/vendor.h:10,
                 from src/main.cpp:1:
include/olcPGEX_AudioListener.h:202:14: warning: inline function ‘void olcPGEX_AudioListener::AudioSystemInit()’ used but never defined
  202 |  inline void AudioSystemInit();
      |              ^~~~~~~~~~~~~~~
In file included from include/vendor.h:11,
                 from src/main.cpp:1:
include/olcPGEX_AudioSource.h:106:14: warning: inline function ‘void olcPGEX_AudioSource::LoadAudioSample(int, const char*)’ used but never defined
  106 |  inline void LoadAudioSample(int ID, const char* fileName);
      |              ^~~~~~~~~~~~~~~
include/olcPGEX_AudioSource.h:109:14: warning: inline function ‘void olcPGEX_AudioSource::Play(float, float, bool, bool)’ used but never defined
  109 |  inline void Play(float speed = 1.0f, float vol = 1.0f, bool looping = false, bool paused = false);
      |              ^~~~
In file included from include/vendor.h:10,
                 from src/main.cpp:1:
include/olcPGEX_AudioListener.h:203:14: warning: inline function ‘void olcPGEX_AudioListener::AudioSystemDestroy()’ used but never defined
  203 |  inline void AudioSystemDestroy();
      |              ^~~~~~~~~~~~~~~~~~
g++ -std=c++17 -ggdb3 -Og -Bstatic -static-libgcc -static-libstdc++ -o bin/Untitled obj/SceneManager.o obj/SceneSplash.o obj/vendor.o obj/main.o -Llib -L/opt/libraries/soloud20200207/lib -lX11 -lGL -lpthread -lpng -lstdc++fs -lsoloud_static -lSDL2 -ldl
/usr/bin/ld: obj/main.o: in function `Example::OnUserDestroy()':
/home/jon/Projects/Untitled/src/main.cpp:62: undefined reference to `olcPGEX_AudioListener::AudioSystemDestroy()'
/usr/bin/ld: obj/main.o: in function `Example::OnUserUpdate(float)':
/home/jon/Projects/Untitled/src/main.cpp:47: undefined reference to `olcPGEX_AudioSource::Play(float, float, bool, bool)'
/usr/bin/ld: obj/main.o: in function `Example::OnUserCreate()':
/home/jon/Projects/Untitled/src/main.cpp:26: undefined reference to `olcPGEX_AudioListener::AudioSystemInit()'
/usr/bin/ld: /home/jon/Projects/Untitled/src/main.cpp:28: undefined reference to `olcPGEX_AudioSource::LoadAudioSample(int, char const*)'
collect2: error: ld returned 1 exit status
make: *** [Makefile:44: bin/Untitled] Error 1
```

Removing the ``inline`` keyword from the declarations solved the issue.

```cpp
int nSampleID = GAME2D::AUDIO::NULL_SND;
```

Removed superfluous assignment because:

*  it is overwritten by the constructor, therefore is never actually used.
*  it introduces a dependency on a header which is not needed for the PGEX to function on it's own.

These changes tested working on Linux and Emscripten!
